### PR TITLE
Submit form and display result without reloading the page (AJAX request tested)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,6 @@ GEM
       io-console (~> 0.5)
     rexml (3.3.1)
       strscan
-    rinruby (2.1.0)
     rubyzip (2.3.2)
     selenium-webdriver (4.22.0)
       base64 (~> 0.2)
@@ -269,7 +268,6 @@ DEPENDENCIES
   jbuilder
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
-  rinruby (~> 2.1)
   selenium-webdriver
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,8 @@ class PagesController < ApplicationController
     # Capture the result
     @result = output.strip
 
-    render :home
+    # Render the result as JSON
+    render json: { result: @result }
 
     # require "rinruby"
     # R.eval "print('Hello from R')"

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "weight", "result2", "form"]
+  static targets = [ "weight", "result2", "form", "result"]
 
   connect() {
     console.log("Hello World!")
@@ -11,33 +11,73 @@ export default class extends Controller {
 
   addiction(event) {
     event.preventDefault()
-    console.log(event)
-    console.log(this.result)
+
+    // Get form data
+    const form = event.target
+    console.log(form)
+
+    // Create FormData object
+    const formData = new FormData(form)
+    console.log(formData)
+
+    // Create AJAX request
+    const resquestDetails = {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content
+      },
+      body: formData
+    }
+
+    // Send AJAX request to the backend without reloading the page
+    fetch('/calculate', resquestDetails)
+    .then(response => response.json())
+
+    // Handle the response
+    .then(data => {
+      console.log(data)
+
+      // Update the resultTarget with the result
+      this.resultTarget.textContent = `Result: ${data.result}`;
+    })
   }
 
+  // Calculate the sum of the weights and display it
+  // when the form is submitted
   calculate(event) {
     event.preventDefault()
     console.log(this.weightTarget)
+
+    // Get the weights (in case there are multiple inputs' rows)
     const weights = document.querySelectorAll(".weight")
     console.log(weights)
+
+    // Calculate the sum of the weights
     let result = 0
     weights.forEach((weight) => {
       console.log(weight.value)
       result += parseInt(weight.value)
     })
+
+    // Display the result by updating the div
     console.log(result)
     this.result2Target.innerHTML = result
   }
 
+  // Add a new row to the form
   addrow(event) {
     event.preventDefault()
     console.log(event)
     console.log(this.formTarget)
+
+    // Create a new row
     const row = document.createElement("div")
     row.innerHTML = `
       <label for="weight">Poids 2</label>
       <input type="number" name="weight" data-hello-target="weight" class="weight">
     `
+
+    // Append the row to the form
     this.formTarget.appendChild(row)
   }
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,22 +2,24 @@
 <br>
 
 <p>Add the two numbers:</p>
-<div data-controller="hello" data-result=<%= @result %>>
-  <%= form_tag(calculate_path, method: :post, remote: true, data: { turbo: false }) do %>
+<div data-controller="hello">
+  <%= form_tag(calculate_path, method: :post, remote: true, data: { turbo: false, action: "hello#addiction" }) do %>
     <%= label_tag(:var1, "Variable 1:") %>
     <%= number_field_tag(:var1) %>
 
     <%= label_tag(:var2, "Variable 2:") %>
     <%= number_field_tag(:var2) %>
 
-    <!-- <%= submit_tag "Calculate", data: { action: "hello#addiction"} %> -->
-    <%= submit_tag "Calculate"%>
+    <%= submit_tag "Calculate" %>
+    <!-- <%= submit_tag "Calculate"%> -->
   <% end %>
+  <div data-hello-target="result">
+  </div>
 </div>
 
-<br>
-<p>Result of the addition:</p>
 <% if @result %>
+  <br>
+  <p>Result of the addition:</p>
   <p><%= @result %></p>
 <% end %>
 
@@ -51,6 +53,8 @@
 
 
 <!-- Test for Stimulus (add a new field to the form) -->
+<hr>
+<br>
 <h3>Calculer le poids</h3>
 <br>
 <div data-controller="hello">


### PR DESCRIPTION
- An AJAX request will be created and sent to the server without reloading the page. 
<img width="374" alt="Capture d’écran 2024-07-12 à 13 27 45" src="https://github.com/user-attachments/assets/070c5106-2fdb-43f2-8ea1-1f4a447307c6">

- pages_controller in the backend recuperates the data and does the math. The result will be rendered in JSON format.
`render json: { result: @result }`
- The result is sent back to JS to be inserted directly to HTML.