### PR TITLE
Setup Tailwind CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "tailwindcss-rails", "~> 2.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,18 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.1)
     strscan (3.1.0)
+    tailwindcss-rails (2.6.2)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.2-aarch64-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.2-arm-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.2-arm64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.2-x86_64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.2-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.1)
     timeout (0.4.1)
     turbo-rails (2.0.5)
@@ -272,6 +284,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails
+  tailwindcss-rails (~> 2.6)
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,12 +5,15 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <%= yield %>
+    <main class="container mx-auto mt-28 px-5 flex">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,73 +1,76 @@
-<h1>ACT Project App Homepage</h1>
-<br>
-
-<p>Add the two numbers:</p>
-<div data-controller="hello">
-  <%= form_tag(calculate_path, method: :post, remote: true, data: { turbo: false, action: "hello#addiction" }) do %>
-    <%= label_tag(:var1, "Variable 1:") %>
-    <%= number_field_tag(:var1) %>
-
-    <%= label_tag(:var2, "Variable 2:") %>
-    <%= number_field_tag(:var2) %>
-
-    <%= submit_tag "Calculate" %>
-    <!-- <%= submit_tag "Calculate"%> -->
-  <% end %>
-  <div data-hello-target="result">
+<div>
+  <div class="max-w-2xl mx-auto text-center">
+    <h2 class="font-bold">ACT Project</h2>
   </div>
-</div>
+  <hr>
+  <p>Add the two numbers:</p>
+  <div data-controller="hello">
+    <%= form_tag(calculate_path, method: :post, remote: true, data: { turbo: false, action: "hello#addiction" }) do %>
+      <%= label_tag(:var1, "Variable 1:") %>
+      <%= number_field_tag(:var1) %>
 
-<% if @result %>
-  <br>
-  <p>Result of the addition:</p>
-  <p><%= @result %></p>
-<% end %>
+      <%= label_tag(:var2, "Variable 2:") %>
+      <%= number_field_tag(:var2) %>
 
-
-<!-- Test for nested form -->
-<br>
-<h3>Calcul de la prochaine dose</h3>
-<%= form_with model: @patient do |form| %>
-  <%= form.label :weight, "Poids du patient" %>
-  <%= form.number_field :weight %>
-  <div>
-    <%= form.fields_for :acts do |acts_form| %>
-      <%= acts_form.label :act_value, "Valeur d'ACT mesurée" %>
-      <%= acts_form.number_field :act_value %>
-
-      <%= acts_form.label :act_time, "Temps" %>
-      <%= acts_form.datetime_field :act_time %>
+      <%= submit_tag "Calculate" %>
+      <!-- <%= submit_tag "Calculate"%> -->
     <% end %>
-  </div>
-  <div>
-    <%= form.fields_for :heparins do |heparins_form| %>
-      <%= heparins_form.label :bolus_given, "Dose d'Heparin injectée" %>
-      <%= heparins_form.number_field :bolus_given %>
-
-      <%= heparins_form.label :act_time, "Temps" %>
-      <%= heparins_form.text_field :bolus_time %>
-    <% end %>
-  </div>
-  <%= form.submit %>
-<% end %>
-
-
-<!-- Test for Stimulus (add a new field to the form) -->
-<hr>
-<br>
-<h3>Calculer le poids</h3>
-<br>
-<div data-controller="hello">
-  <%= form_with model: @patient do |form| %>
-    <div data-hello-target="form">
-      <div>
-        <%= form.label :weight, "Poids du patient" %>
-        <%= form.number_field :weight, data: {:hello_target => "weight"}, class: "weight"  %>
-      </div>
+    <div data-hello-target="result">
     </div>
-    <button data-action="click->hello#addrow">Ajouter un champ</button>
-    <%= form.submit "Calculer le poids", data: {:action => "click->hello#calculate"} %>
+  </div>
+
+  <% if @result %>
+    <br>
+    <p>Result of the addition:</p>
+    <p><%= @result %></p>
   <% end %>
+
+
+  <!-- Test for nested form -->
   <br>
-  <div data-hello-target="result2"></div>
+  <h3>Calcul de la prochaine dose</h3>
+  <%= form_with model: @patient do |form| %>
+    <%= form.label :weight, "Poids du patient" %>
+    <%= form.number_field :weight %>
+    <div>
+      <%= form.fields_for :acts do |acts_form| %>
+        <%= acts_form.label :act_value, "Valeur d'ACT mesurée" %>
+        <%= acts_form.number_field :act_value %>
+
+        <%= acts_form.label :act_time, "Temps" %>
+        <%= acts_form.datetime_field :act_time %>
+      <% end %>
+    </div>
+    <div>
+      <%= form.fields_for :heparins do |heparins_form| %>
+        <%= heparins_form.label :bolus_given, "Dose d'Heparin injectée" %>
+        <%= heparins_form.number_field :bolus_given %>
+
+        <%= heparins_form.label :act_time, "Temps" %>
+        <%= heparins_form.text_field :bolus_time %>
+      <% end %>
+    </div>
+    <%= form.submit %>
+  <% end %>
+
+
+  <!-- Test for Stimulus (add a new field to the form) -->
+  <hr>
+  <br>
+  <h3>Calculer le poids</h3>
+  <br>
+  <div data-controller="hello">
+    <%= form_with model: @patient do |form| %>
+      <div data-hello-target="form">
+        <div>
+          <%= form.label :weight, "Poids du patient" %>
+          <%= form.number_field :weight, data: {:hello_target => "weight"}, class: "weight"  %>
+        </div>
+      </div>
+      <button data-action="click->hello#addrow">Ajouter un champ</button>
+      <%= form.submit "Calculer le poids", data: {:action => "click->hello#calculate"} %>
+    <% end %>
+    <br>
+    <div data-hello-target="result2"></div>
+  </div>
 </div>

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,3 +33,6 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+# Allow 'rails server' to be run in development with Tailwind CSS JIT
+plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,23 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}',
+    './app/views/**/*.html.erb'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}


### PR DESCRIPTION
- Set up Tailwind CSS by following the documentation for [Tailwind CSS in Rails](https://tailwindcss.com/docs/guides/ruby-on-rails)
- Added path to all views' file `'./app/views/**/*.html.erb'`
- Added `plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"` to puma.rb to integrate Tailwind "watch" mode with Rails server (changes are automatically reflected in the generated CSS output)

In case we don't add `plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"` to puma's config file, we must start our development web server with `bin/dev` (instead of `rails server`) which will use Foreman to not only start Puma but also make Tailwind listen for changes in our CSS and (re)build the CSS file on the fly.