### PR TITLE
quick fix: after folding result section, going back to the result button

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -573,7 +573,7 @@
                 of the website</a>
               </p>
               <div id="section-result-interpretation" class="flex justify-center" data-action="click->toggle#fire">
-                <p class="lg:px-3 lg:py-1 lg:text-base px-2 py-0.5 text-sm font-bold text-white bg-icon-color rounded lg:hover:bg-gray-500 active:bg-gray-600 active:scale-95 focus:outline-none focus:shadow-outline lg:mb-6 mb-3">Fold section</p>
+                <a href="#section-result-interpretation" class="lg:px-3 lg:py-1 lg:text-base px-2 py-0.5 text-sm font-bold text-white bg-icon-color rounded lg:hover:bg-gray-500 active:bg-gray-600 active:scale-95 focus:outline-none focus:shadow-outline lg:mb-6 mb-3">Fold section</a>
               </div>
             </div>
 


### PR DESCRIPTION
Before the fix, after folding, the user was on the biblio part which was not optimal